### PR TITLE
#109 - Fix Keycloak IDX10500 by configuring TokenValidationParameters in place

### DIFF
--- a/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
+++ b/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
@@ -14,11 +14,11 @@
     <Description>Core security services for ASP.NET Core: authentication, authorization, user management and repositories.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management Core AspNetCore Cauca</PackageTags>
-    <PackageReleaseNotes>10.3.1 — Bump packages for vulnerability fixes.</PackageReleaseNotes>
-    <Version>10.3.1</Version>
+    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
+    <Version>10.3.2-beta1</Version>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <AssemblyVersion>10.3.1</AssemblyVersion>
-    <FileVersion>10.3.1</FileVersion>
+    <AssemblyVersion>10.3.2</AssemblyVersion>
+    <FileVersion>10.3.2</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
+++ b/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
@@ -14,8 +14,8 @@
     <Description>Core security services for ASP.NET Core: authentication, authorization, user management and repositories.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management Core AspNetCore Cauca</PackageTags>
-    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
-    <Version>10.3.2-beta1</Version>
+    <PackageReleaseNotes>10.3.2 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
+    <Version>10.3.2</Version>
     <Configurations>Debug;Release;NuGet</Configurations>
     <AssemblyVersion>10.3.2</AssemblyVersion>
     <FileVersion>10.3.2</FileVersion>

--- a/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
+++ b/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
@@ -4,7 +4,7 @@
 	  <IsPackable>true</IsPackable>
 	  <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <Version>10.3.2-beta1</Version>
+    <Version>10.3.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <RepositoryUrl>https://github.com/CAUCA-9-1-1/cause-security-management</RepositoryUrl>
 	  <PackageProjectUrl>https://github.com/CAUCA-9-1-1/cause-security-management</PackageProjectUrl>
@@ -13,7 +13,7 @@
     <Authors>Fred Catellier</Authors>
     <Description>Base models for the Causee.SecurityManagement's library.</Description>
     <Copyright>CAUCA 9-1-1 2025</Copyright>
-    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
+    <PackageReleaseNotes>10.3.2 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
     <Company>CAUCA 9-1-1</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
+++ b/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
@@ -4,16 +4,16 @@
 	  <IsPackable>true</IsPackable>
 	  <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <Version>10.3.0</Version>
+    <Version>10.3.2-beta1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <RepositoryUrl>https://github.com/CAUCA-9-1-1/cause-security-management</RepositoryUrl>
 	  <PackageProjectUrl>https://github.com/CAUCA-9-1-1/cause-security-management</PackageProjectUrl>
-    <AssemblyVersion>10.3.0</AssemblyVersion>
-    <FileVersion>10.3.0</FileVersion>
+    <AssemblyVersion>10.3.2</AssemblyVersion>
+    <FileVersion>10.3.2</FileVersion>
     <Authors>Fred Catellier</Authors>
     <Description>Base models for the Causee.SecurityManagement's library.</Description>
     <Copyright>CAUCA 9-1-1 2025</Copyright>
-    <PackageReleaseNotes>10.3.0 — Adds an overridable AdditionalInformation field on the user management DTOs (UserForGroupDto, GroupUserDto), populated server-side via IUserAdditionalInformationProvider&lt;TUser&gt;. All published packages must be upgraded together. Backwards compatible with 10.2.x consumers.</PackageReleaseNotes>
+    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
     <Company>CAUCA 9-1-1</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Cause.SecurityManagement.Tests/Authentication/KeycloakAuthenticationBuilderTests.cs
+++ b/Cause.SecurityManagement.Tests/Authentication/KeycloakAuthenticationBuilderTests.cs
@@ -1,0 +1,73 @@
+using System;
+using AwesomeAssertions;
+using Cause.SecurityManagement.Authentication;
+using Cause.SecurityManagement.Core.Authentication;
+using Cause.SecurityManagement.Models.Configuration;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Cause.SecurityManagement.Tests.Authentication;
+
+[TestFixture]
+public class KeycloakAuthenticationBuilderTests
+{
+    private JwtBearerOptions options;
+
+    [SetUp]
+    public void SetUpTest()
+    {
+        var securityConfiguration = new SecurityConfiguration
+        {
+            SecretKey = "test-secret-key-with-enough-length-1234567890",
+            Issuer = "regular-user-issuer",
+            PackageName = "regular-user-audience"
+        };
+        var keycloakConfiguration = new KeycloakConfiguration
+        {
+            MetadataAddress = "https://keycloak.example.com/.well-known/openid-configuration",
+            ValidIssuer = "https://keycloak.example.com/realms/test",
+            Resource = "test-client",
+            SslRequired = true,
+            ValidateSigningKey = true
+        };
+
+        var services = new ServiceCollection();
+        services.AddTokenAuthentication(securityConfiguration, keycloakConfiguration);
+
+        using var provider = services.BuildServiceProvider();
+        options = provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>().Get(CustomAuthSchemes.KeycloakAuthentication);
+    }
+
+    [Test]
+    public void KeycloakScheme_WhenConfigured_ShouldWireJwtBearerOptionsFromConfiguration()
+    {
+        options.Audience.Should().Be("test-client");
+        options.MetadataAddress.Should().Be("https://keycloak.example.com/.well-known/openid-configuration");
+        options.RequireHttpsMetadata.Should().BeTrue();
+        options.SaveToken.Should().BeTrue();
+    }
+
+    [Test]
+    public void KeycloakScheme_WhenConfigured_ShouldWireTokenValidationParametersFromConfiguration()
+    {
+        options.TokenValidationParameters.Should().NotBeNull();
+        options.TokenValidationParameters.ValidIssuer.Should().Be("https://keycloak.example.com/realms/test");
+        options.TokenValidationParameters.NameClaimType.Should().Be("preferred_username");
+        options.TokenValidationParameters.RoleClaimType.Should().Be("role");
+        options.TokenValidationParameters.ClockSkew.Should().Be(TimeSpan.Zero);
+        options.TokenValidationParameters.ValidateIssuer.Should().BeTrue();
+        options.TokenValidationParameters.ValidateAudience.Should().BeTrue();
+        options.TokenValidationParameters.ValidateLifetime.Should().BeTrue();
+        options.TokenValidationParameters.ValidateIssuerSigningKey.Should().BeTrue();
+    }
+
+    // Regression guard: the actual signing-key resolution bug (JwtBearer 10.0.9 failing every
+    // Keycloak token with IDX10500 "No security keys were provided to validate the signature")
+    // only reproduces through a real token-validation round-trip against an OIDC metadata
+    // endpoint, not through inspecting configured values in isolation. That round-trip is
+    // covered by KeycloakJwtBearerIntegrationTests, which fails if
+    // KeycloakAuthenticationBuilder goes back to replacing options.TokenValidationParameters
+    // wholesale instead of mutating the framework-provided instance in place.
+}

--- a/Cause.SecurityManagement.Tests/Authentication/KeycloakJwtBearerIntegrationTests.cs
+++ b/Cause.SecurityManagement.Tests/Authentication/KeycloakJwtBearerIntegrationTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Cause.SecurityManagement.Authentication;
+using Cause.SecurityManagement.Core.Authentication;
+using Cause.SecurityManagement.Models.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+
+namespace Cause.SecurityManagement.Tests.Authentication;
+
+[TestFixture]
+public class KeycloakJwtBearerIntegrationTests
+{
+    private const string Issuer = "http://keycloak-test/realms/test";
+    private const string Audience = "test-client";
+
+    private RSA rsa;
+    private RsaSecurityKey signingKey;
+    private IHost metadataHost;
+    private TestServer metadataServer;
+    private IHost apiHost;
+    private TestServer apiServer;
+
+    [SetUp]
+    public async Task SetUpTest()
+    {
+        rsa = RSA.Create(2048);
+        signingKey = new RsaSecurityKey(rsa) { KeyId = "test-key" };
+
+        metadataHost = await CreateMetadataHostAsync(signingKey, Issuer);
+        metadataServer = metadataHost.GetTestServer();
+
+        apiHost = await CreateApiHostAsync(metadataServer);
+        apiServer = apiHost.GetTestServer();
+    }
+
+    [TearDown]
+    public async Task TearDownTest()
+    {
+        if (apiHost != null)
+            await apiHost.StopAsync();
+        apiHost?.Dispose();
+
+        if (metadataHost != null)
+            await metadataHost.StopAsync();
+        metadataHost?.Dispose();
+
+        rsa?.Dispose();
+    }
+
+    [Test]
+    public async Task ValidKeycloakToken_WhenCallingProtectedEndpoint_ShouldReturnOk()
+    {
+        var token = CreateSignedJwt(signingKey);
+        using var client = apiServer.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/secure");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, because: $"authentication should succeed, but got: {body}");
+    }
+
+    private static async Task<IHost> CreateMetadataHostAsync(RsaSecurityKey key, string issuer)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.Configure(app =>
+                {
+                    app.Map("/.well-known/openid-configuration", metadataApp => metadataApp.Run(async context =>
+                    {
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                        {
+                            issuer,
+                            jwks_uri = "http://keycloak-test/jwks"
+                        }));
+                    }));
+                    app.Map("/jwks", jwksApp => jwksApp.Run(async context =>
+                    {
+                        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                        {
+                            keys = new[]
+                            {
+                                new { kty = jwk.Kty, use = "sig", kid = jwk.Kid, e = jwk.E, n = jwk.N, alg = SecurityAlgorithms.RsaSha256 }
+                            }
+                        }));
+                    }));
+                });
+            });
+        return await builder.StartAsync();
+    }
+
+    private static async Task<IHost> CreateApiHostAsync(TestServer metadataTestServer)
+    {
+        var securityConfiguration = new SecurityConfiguration
+        {
+            SecretKey = "test-secret-key-with-enough-length-1234567890",
+            Issuer = "regular-user-issuer",
+            PackageName = "regular-user-audience"
+        };
+        var keycloakConfiguration = new KeycloakConfiguration
+        {
+            MetadataAddress = "http://keycloak-test/.well-known/openid-configuration",
+            ValidIssuer = Issuer,
+            Resource = Audience,
+            SslRequired = false,
+            ShowDebugInfo = true
+        };
+
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddTokenAuthentication(securityConfiguration, keycloakConfiguration);
+                    services.Configure<JwtBearerOptions>(CustomAuthSchemes.KeycloakAuthentication, options =>
+                    {
+                        options.RequireHttpsMetadata = false;
+                        options.BackchannelHttpHandler = metadataTestServer.CreateHandler();
+                    });
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/secure", async context =>
+                        {
+                            var result = await context.AuthenticateAsync(CustomAuthSchemes.KeycloakAuthentication);
+                            if (result.Succeeded)
+                            {
+                                context.Response.StatusCode = StatusCodes.Status200OK;
+                                await context.Response.WriteAsync("ok");
+                            }
+                        });
+                    });
+                });
+            });
+        return await builder.StartAsync();
+    }
+
+    private static string CreateSignedJwt(RsaSecurityKey key)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, "test-user"),
+            new Claim("preferred_username", "test-user"),
+            new Claim("role", "User")
+        };
+        var token = new JwtSecurityToken(Issuer, Audience, claims, notBefore: DateTime.UtcNow.AddMinutes(-1), expires: DateTime.UtcNow.AddMinutes(10), signingCredentials: credentials);
+        return handler.WriteToken(token);
+    }
+}

--- a/Cause.SecurityManagement.Tests/Cause.SecurityManagement.Tests.csproj
+++ b/Cause.SecurityManagement.Tests/Cause.SecurityManagement.Tests.csproj
@@ -6,7 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="nunit" Version="4.6.1" />

--- a/Cause.SecurityManagement/Authentication/KeycloakAuthenticationBuilder.cs
+++ b/Cause.SecurityManagement/Authentication/KeycloakAuthenticationBuilder.cs
@@ -27,8 +27,11 @@ internal static class KeycloakAuthenticationBuilder
         options.Audience = configuration.Audience;
         options.MetadataAddress = configuration.MetadataAddress;
         options.SaveToken = true;
-        options.TokenValidationParameters = GetValidationParameters(configuration);
-        options.Events = new() { OnAuthenticationFailed = context => GetCustomOnAuthenticationFailedResult(context, configuration) };
+        ConfigureValidationParameters(options.TokenValidationParameters, configuration);
+        options.Events = new()
+        {
+            OnAuthenticationFailed = context => GetCustomOnAuthenticationFailedResult(context, configuration)
+        };
     }
 
     private static async Task GetCustomOnAuthenticationFailedResult(AuthenticationFailedContext context, KeycloakConfiguration configuration)
@@ -48,6 +51,7 @@ internal static class KeycloakAuthenticationBuilder
                     ?? Array.Empty<object>();
 
                 var signingKey = context.Options.TokenValidationParameters.IssuerSigningKey;
+                var discoveredConfiguration = await GetDiscoveredConfigurationForDiagnosticsAsync(context);
 
                 var errorResponse = new
                 {
@@ -72,6 +76,7 @@ internal static class KeycloakAuthenticationBuilder
                         SigningKeysCount = signingKeys.Length,
                         SigningKeys = signingKeys
                     },
+                    DiscoveredConfiguration = discoveredConfiguration,
                     Token = token,
                     User = new
                     {
@@ -88,18 +93,36 @@ internal static class KeycloakAuthenticationBuilder
         }
     }
 
-    private static TokenValidationParameters GetValidationParameters(KeycloakConfiguration configuration)
+    private static async Task<object?> GetDiscoveredConfigurationForDiagnosticsAsync(AuthenticationFailedContext context)
     {
-        return new()
+        if (context.Options.ConfigurationManager == null)
+            return null;
+
+        try
         {
-            ValidIssuer = configuration.ValidIssuer,
-            ValidateIssuer = true,
-            ValidateAudience = true,
-            ValidateIssuerSigningKey = configuration.ValidateSigningKey,
-            NameClaimType = "preferred_username",
-            RoleClaimType = "role",
-            ValidateLifetime = true,
-            ClockSkew = TimeSpan.Zero
-        };
+            var discoveredConfiguration = await context.Options.ConfigurationManager.GetConfigurationAsync(context.HttpContext.RequestAborted);
+            return new
+            {
+                discoveredConfiguration.Issuer,
+                SigningKeysCount = discoveredConfiguration.SigningKeys?.Count ?? 0,
+                SigningKeyIds = discoveredConfiguration.SigningKeys?.Select(key => key.KeyId).ToArray() ?? Array.Empty<string>()
+            };
+        }
+        catch (Exception exception)
+        {
+            return new { Error = exception.Message };
+        }
+    }
+
+    private static void ConfigureValidationParameters(TokenValidationParameters validationParameters, KeycloakConfiguration configuration)
+    {
+        validationParameters.ValidIssuer = configuration.ValidIssuer;
+        validationParameters.ValidateIssuer = true;
+        validationParameters.ValidateAudience = true;
+        validationParameters.ValidateIssuerSigningKey = configuration.ValidateSigningKey;
+        validationParameters.NameClaimType = "preferred_username";
+        validationParameters.RoleClaimType = "role";
+        validationParameters.ValidateLifetime = true;
+        validationParameters.ClockSkew = TimeSpan.Zero;
     }
 }

--- a/Cause.SecurityManagement/Cause.SecurityManagement.csproj
+++ b/Cause.SecurityManagement/Cause.SecurityManagement.csproj
@@ -12,8 +12,8 @@
     <Description>ASP.NET Core HTTP integration (controllers, authentication, authorization) for Cause.SecurityManagement.Core.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management AspNetCore Http Controllers Cauca</PackageTags>
-    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
-    <Version>10.3.2-beta1</Version>
+    <PackageReleaseNotes>10.3.2 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
+    <Version>10.3.2</Version>
     <AssemblyVersion>10.3.2</AssemblyVersion>
     <FileVersion>10.3.2</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Cause.SecurityManagement/Cause.SecurityManagement.csproj
+++ b/Cause.SecurityManagement/Cause.SecurityManagement.csproj
@@ -12,10 +12,10 @@
     <Description>ASP.NET Core HTTP integration (controllers, authentication, authorization) for Cause.SecurityManagement.Core.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management AspNetCore Http Controllers Cauca</PackageTags>
-    <PackageReleaseNotes>10.3.1 — Bump packages for vulnerability fixes.</PackageReleaseNotes>
-    <Version>10.3.1</Version>
-    <AssemblyVersion>10.3.1</AssemblyVersion>
-    <FileVersion>10.3.1</FileVersion>
+    <PackageReleaseNotes>10.3.2-beta1 — Fixes Keycloak JWT authentication returning 401 (IDX10500 "no security keys") under Microsoft.AspNetCore.Authentication.JwtBearer 10.0.9: the Keycloak scheme now configures the framework-provided TokenValidationParameters in place instead of replacing it, so OIDC signing keys resolve from metadata correctly. All published packages must be upgraded together.</PackageReleaseNotes>
+    <Version>10.3.2-beta1</Version>
+    <AssemblyVersion>10.3.2</AssemblyVersion>
+    <FileVersion>10.3.2</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

Fixes the Keycloak `401 / IDX10500 "No security keys were provided to validate the signature"` regression where every Keycloak-authenticated user is rejected even with a valid token.

Closes #109.

## Root cause

The failure appears the moment the transitive `Microsoft.AspNetCore.Authentication.JwtBearer` dependency resolves to **10.0.9** (pulled in by `Cause.SecurityManagement 10.3.0` via its floating `10.0.*` pin; `10.2.0` resolved `10.0.8`, which worked). The library's authentication code is byte-identical between the `10.2.0` and `10.3.0` tags, so the only behavioural change is the JwtBearer patch bump.

`KeycloakAuthenticationBuilder.GetDefautKeycloakBearerOptions` **replaced** the framework-provided `JwtBearerOptions.TokenValidationParameters` with a brand-new instance:

```csharp
options.TokenValidationParameters = GetValidationParameters(configuration); // replaced the framework instance
```

Under JwtBearer **10.0.9** that replaced instance is no longer wired to resolve signing keys from the OIDC metadata/JWKS document, so validation runs with **zero** signing keys and every RS256 Keycloak token fails signature validation. The regular-user (static symmetric key) and console-certificate schemes are unaffected because they don't rely on OIDC metadata key resolution — which is why the symptom is Keycloak-only.

## Fix

- Configure the **existing** `options.TokenValidationParameters` in place instead of replacing it (`ConfigureValidationParameters(options.TokenValidationParameters, configuration)`).
- Enrich the `ShowDebugInfo` failure body with the signing keys actually discovered through the OIDC `ConfigurationManager` (issuer + key count + kids). The previous debug output only reported the *static* `TokenValidationParameters.IssuerSigningKeys`, which is always empty for a metadata-based Keycloak setup even when auth works — that made the real failure look like a misconfiguration.

## Verification

- New in-memory OIDC integration test (`KeycloakJwtBearerIntegrationTests`) drives the **real** `AddTokenAuthentication` wiring against a fake discovery/JWKS endpoint with an RSA-signed token. It **fails (401 / IDX10500) before the fix** and **passes (200) after**, running against JwtBearer 10.0.9.
- New unit test (`KeycloakAuthenticationBuilderTests`) asserts the `KeycloakAuthentication` `JwtBearerOptions` are wired correctly.
- `dotnet build` — 0 warnings, 0 errors. `dotnet test` — 184/184 passing.

## Note on "works locally, fails in Kubernetes"

Because the library pins JwtBearer as floating `10.0.*` and consumers have **no `packages.lock.json`**, different environments can restore different patch versions: a dev machine may already have `10.0.8` cached while a fresh CI/container restore pulls `10.0.9`. That difference — not the OS — is what makes it "work locally but fail when deployed." This fix makes the wiring robust to `10.0.9`; adding a lock file (and/or a bounded JwtBearer range in the library) is recommended as a follow-up to prevent future silent transitive drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
