### PR TITLE
#113 - Add token-only external-system authentication (10.5.0-beta1)

### DIFF
--- a/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
+++ b/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
@@ -19,7 +19,7 @@
 authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
 is unchanged. All published packages must be upgraded together.
     </PackageReleaseNotes>
-    <Version>10.5.0</Version>
+    <Version>10.5.0-beta1</Version>
     <Configurations>Debug;Release;NuGet</Configurations>
     <AssemblyVersion>10.5.0</AssemblyVersion>
     <FileVersion>10.5.0</FileVersion>

--- a/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
+++ b/Cause.SecurityManagement.Core/Cause.SecurityManagement.Core.csproj
@@ -14,11 +14,15 @@
     <Description>Core security services for ASP.NET Core: authentication, authorization, user management and repositories.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management Core AspNetCore Cauca</PackageTags>
-    <PackageReleaseNotes>Add per-system ExternalSystem authentication method (Token/Certificate) with strict binding and a new AddDualExternalSystemAuthentication scheme that routes each request to certificate or JWT bearer. The authenticated principal is stamped with an externalSystemAuthenticationType claim (Certificate by the certificate handler; Token via OnTokenValidated, gated on the ExternalSystem role) so consumers can tell internal token callers from external certificate callers. Adds the split-out Cause.SecurityManagement.Wolverine.ExternalSystem endpoints package (logon/refresh/GetCurrentUser). NOTE: AuthenticationType defaults to Token; existing certificate-based external systems must be set to Certificate. The ExternalSystems table needs a non-nullable AuthenticationType column (default 0 = Token); this library ships no migrations.</PackageReleaseNotes>
-    <Version>10.4.0</Version>
+    <PackageReleaseNotes>
+10.5.0 — Adds AddExternalSystemTokenAuthentication for token-only external-system
+authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
+is unchanged. All published packages must be upgraded together.
+    </PackageReleaseNotes>
+    <Version>10.5.0</Version>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <AssemblyVersion>10.4.0</AssemblyVersion>
-    <FileVersion>10.4.0</FileVersion>
+    <AssemblyVersion>10.5.0</AssemblyVersion>
+    <FileVersion>10.5.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Cause.SecurityManagement.Integration.Tests/Infrastructure/DatabaseFixture.cs
+++ b/Cause.SecurityManagement.Integration.Tests/Infrastructure/DatabaseFixture.cs
@@ -1,8 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using Testcontainers.PostgreSql;
+using Cause.SecurityManagement.Integration.Tests.Infrastructure;
 
-namespace Cause.SecurityManagement.Integration.Tests.Infrastructure;
+namespace Cause.SecurityManagement.Integration.Tests;
 
 [SetUpFixture]
 public class DatabaseFixture

--- a/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
+++ b/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
@@ -4,7 +4,7 @@
 	  <IsPackable>true</IsPackable>
 	  <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <Version>10.5.0</Version>
+    <Version>10.5.0-beta1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <RepositoryUrl>https://github.com/CAUCA-9-1-1/cause-security-management</RepositoryUrl>
 	  <PackageProjectUrl>https://github.com/CAUCA-9-1-1/cause-security-management</PackageProjectUrl>

--- a/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
+++ b/Cause.SecurityManagement.Models/Cause.SecurityManagement.Models.csproj
@@ -4,16 +4,20 @@
 	  <IsPackable>true</IsPackable>
 	  <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <Version>10.4.0</Version>
+    <Version>10.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <RepositoryUrl>https://github.com/CAUCA-9-1-1/cause-security-management</RepositoryUrl>
 	  <PackageProjectUrl>https://github.com/CAUCA-9-1-1/cause-security-management</PackageProjectUrl>
-    <AssemblyVersion>10.4.0</AssemblyVersion>
-    <FileVersion>10.4.0</FileVersion>
+    <AssemblyVersion>10.5.0</AssemblyVersion>
+    <FileVersion>10.5.0</FileVersion>
     <Authors>Fred Catellier</Authors>
     <Description>Base models for the Causee.SecurityManagement's library.</Description>
     <Copyright>CAUCA 9-1-1 2025</Copyright>
-    <PackageReleaseNotes>Add per-system ExternalSystem authentication method (Token/Certificate) with strict binding and a new AddDualExternalSystemAuthentication scheme that routes each request to certificate or JWT bearer. The authenticated principal is stamped with an externalSystemAuthenticationType claim (Certificate by the certificate handler; Token via OnTokenValidated, gated on the ExternalSystem role) so consumers can tell internal token callers from external certificate callers. Adds the split-out Cause.SecurityManagement.Wolverine.ExternalSystem endpoints package (logon/refresh/GetCurrentUser). NOTE: AuthenticationType defaults to Token; existing certificate-based external systems must be set to Certificate. The ExternalSystems table needs a non-nullable AuthenticationType column (default 0 = Token); this library ships no migrations.</PackageReleaseNotes>
+    <PackageReleaseNotes>
+10.5.0 — Adds AddExternalSystemTokenAuthentication for token-only external-system
+authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
+is unchanged. All published packages must be upgraded together.
+    </PackageReleaseNotes>
     <Company>CAUCA 9-1-1</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/Cause.SecurityManagement.Tests/Authentication/ExternalSystemAuthenticationExtensionsTests.cs
+++ b/Cause.SecurityManagement.Tests/Authentication/ExternalSystemAuthenticationExtensionsTests.cs
@@ -125,4 +125,80 @@ public class ExternalSystemAuthenticationExtensionsTests
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Test]
+    public void AddExternalSystemTokenAuthentication_WhenConfigured_ShouldSetTokenSchemeAsDefault()
+    {
+        var securityConfiguration = new SecurityConfiguration
+        {
+            SecretKey = "test-secret-key-with-enough-length-1234567890",
+            Issuer = "internal-system-issuer",
+            PackageName = "internal-system-audience"
+        };
+
+        var services = new ServiceCollection();
+        services.AddExternalSystemTokenAuthentication(securityConfiguration);
+
+        using var provider = services.BuildServiceProvider();
+        var authenticationOptions = provider.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
+
+        authenticationOptions.DefaultAuthenticateScheme.Should().Be(CustomAuthSchemes.ExternalSystemTokenAuthentication);
+        authenticationOptions.DefaultChallengeScheme.Should().Be(CustomAuthSchemes.ExternalSystemTokenAuthentication);
+        authenticationOptions.DefaultScheme.Should().Be(CustomAuthSchemes.ExternalSystemTokenAuthentication);
+    }
+
+    [Test]
+    public void AddExternalSystemTokenAuthentication_WhenConfigured_ShouldWireTokenValidationParametersFromConfiguration()
+    {
+        var securityConfiguration = new SecurityConfiguration
+        {
+            SecretKey = "test-secret-key-with-enough-length-1234567890",
+            Issuer = "internal-system-issuer",
+            PackageName = "internal-system-audience"
+        };
+
+        var services = new ServiceCollection();
+        services.AddExternalSystemTokenAuthentication(securityConfiguration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(CustomAuthSchemes.ExternalSystemTokenAuthentication);
+
+        options.TokenValidationParameters.ValidIssuer.Should().Be("internal-system-issuer");
+        options.TokenValidationParameters.ValidAudience.Should().Be("internal-system-audience");
+        options.TokenValidationParameters.ValidateLifetime.Should().BeTrue();
+        options.TokenValidationParameters.ClockSkew.Should().Be(TimeSpan.Zero);
+        options.SaveToken.Should().BeTrue();
+    }
+
+    [Test]
+    public void AddExternalSystemTokenAuthentication_ShouldNotRegisterCertificateOrPolicyScheme()
+    {
+        var securityConfiguration = new SecurityConfiguration
+        {
+            SecretKey = "test-secret-key-with-enough-length-1234567890",
+            Issuer = "internal-system-issuer",
+            PackageName = "internal-system-audience"
+        };
+
+        var services = new ServiceCollection();
+        services.AddExternalSystemTokenAuthentication(securityConfiguration);
+
+        using var provider = services.BuildServiceProvider();
+        var schemeProvider = provider.GetRequiredService<Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider>();
+
+        schemeProvider.GetSchemeAsync(CustomAuthSchemes.ExternalSystemTokenAuthentication).Result.Should().NotBeNull();
+        schemeProvider.GetSchemeAsync(CustomAuthSchemes.CertificateAuthentication).Result.Should().BeNull();
+        schemeProvider.GetSchemeAsync(CustomAuthSchemes.DualExternalSystemScheme).Result.Should().BeNull();
+    }
+
+    [Test]
+    public void AddExternalSystemTokenAuthentication_WithNullConfiguration_ShouldThrowArgumentNullException()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddExternalSystemTokenAuthentication(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/Cause.SecurityManagement.Wolverine.ExternalSystem/Cause.SecurityManagement.Wolverine.ExternalSystem.csproj
+++ b/Cause.SecurityManagement.Wolverine.ExternalSystem/Cause.SecurityManagement.Wolverine.ExternalSystem.csproj
@@ -17,7 +17,7 @@
 authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
 is unchanged. All published packages must be upgraded together.
     </PackageReleaseNotes>
-    <Version>10.5.0</Version>
+    <Version>10.5.0-beta1</Version>
     <AssemblyVersion>10.5.0</AssemblyVersion>
     <FileVersion>10.5.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Cause.SecurityManagement.Wolverine.ExternalSystem/Cause.SecurityManagement.Wolverine.ExternalSystem.csproj
+++ b/Cause.SecurityManagement.Wolverine.ExternalSystem/Cause.SecurityManagement.Wolverine.ExternalSystem.csproj
@@ -12,10 +12,14 @@
     <Description>External-system authentication Wolverine HTTP endpoints (logon/refresh) for Cause.SecurityManagement.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management Wolverine ExternalSystem Cauca</PackageTags>
-    <PackageReleaseNotes>Add per-system ExternalSystem authentication method (Token/Certificate) with strict binding and a new AddDualExternalSystemAuthentication scheme that routes each request to certificate or JWT bearer. The authenticated principal is stamped with an externalSystemAuthenticationType claim (Certificate by the certificate handler; Token via OnTokenValidated, gated on the ExternalSystem role) so consumers can tell internal token callers from external certificate callers. Adds the split-out Cause.SecurityManagement.Wolverine.ExternalSystem endpoints package (logon/refresh/GetCurrentUser). NOTE: AuthenticationType defaults to Token; existing certificate-based external systems must be set to Certificate. The ExternalSystems table needs a non-nullable AuthenticationType column (default 0 = Token); this library ships no migrations.</PackageReleaseNotes>
-    <Version>10.4.0</Version>
-    <AssemblyVersion>10.4.0</AssemblyVersion>
-    <FileVersion>10.4.0</FileVersion>
+    <PackageReleaseNotes>
+10.5.0 — Adds AddExternalSystemTokenAuthentication for token-only external-system
+authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
+is unchanged. All published packages must be upgraded together.
+    </PackageReleaseNotes>
+    <Version>10.5.0</Version>
+    <AssemblyVersion>10.5.0</AssemblyVersion>
+    <FileVersion>10.5.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Cause.SecurityManagement/Authentication/ExternalSystemAuthenticationExtensions.cs
+++ b/Cause.SecurityManagement/Authentication/ExternalSystemAuthenticationExtensions.cs
@@ -32,27 +32,7 @@ public static class ExternalSystemAuthenticationExtensions
         services
             .AddAuthenticationWithScheme(CustomAuthSchemes.DualExternalSystemScheme)
             .AddScheme<CertificateAuthenticationOptions, CertificateAuthenticationHandler>(CustomAuthSchemes.CertificateAuthentication, _ => { })
-            .AddJwtBearer(CustomAuthSchemes.ExternalSystemTokenAuthentication, options =>
-            {
-                options.RequireHttpsMetadata = false;
-                options.SaveToken = true;
-                options.TokenValidationParameters = RegularUserJwtAuthenticationBuilder.GetAuthenticationParameters(
-                    configuration.SecretKey, configuration.Issuer, configuration.PackageName);
-                options.Events = new JwtBearerEvents
-                {
-                    OnAuthenticationFailed = RegularUserJwtAuthenticationBuilder.GetCustomOnAuthenticationFailedResult,
-                    OnTokenValidated = context =>
-                    {
-                        if (context.Principal?.Identity is ClaimsIdentity identity
-                            && context.Principal.HasClaim(claim => claim.Type == ClaimTypes.Role && claim.Value == SecurityRoles.ExternalSystem)
-                            && !identity.HasClaim(claim => claim.Type == ExternalSystemClaims.AuthenticationType))
-                        {
-                            identity.AddClaim(new Claim(ExternalSystemClaims.AuthenticationType, ExternalSystemAuthenticationType.Token.ToString()));
-                        }
-                        return Task.CompletedTask;
-                    }
-                };
-            })
+            .AddJwtBearer(CustomAuthSchemes.ExternalSystemTokenAuthentication, options => ConfigureExternalSystemTokenBearer(options, configuration))
             .AddPolicyScheme(CustomAuthSchemes.DualExternalSystemScheme, CustomAuthSchemes.DualExternalSystemScheme, options =>
             {
                 options.ForwardDefaultSelector = context => HasBearerToken(context)
@@ -61,6 +41,48 @@ public static class ExternalSystemAuthenticationExtensions
             });
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds a token-only authentication scheme for external systems. External systems authenticate
+    /// exclusively by bearer token (no client certificate). Use this for APIs that do not support
+    /// certificate authentication.
+    /// </summary>
+    public static IServiceCollection AddExternalSystemTokenAuthentication(this IServiceCollection services, SecurityConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+        services.AddScoped<IClaimsTransformation, ExternalSystemSidClaimsTransformer>();
+
+        services
+            .AddAuthenticationWithScheme(CustomAuthSchemes.ExternalSystemTokenAuthentication)
+            .AddJwtBearer(CustomAuthSchemes.ExternalSystemTokenAuthentication, options => ConfigureExternalSystemTokenBearer(options, configuration));
+
+        return services;
+    }
+
+    private static void ConfigureExternalSystemTokenBearer(JwtBearerOptions options, SecurityConfiguration configuration)
+    {
+        options.RequireHttpsMetadata = false;
+        options.SaveToken = true;
+        options.TokenValidationParameters = RegularUserJwtAuthenticationBuilder.GetAuthenticationParameters(
+            configuration.SecretKey, configuration.Issuer, configuration.PackageName);
+        options.Events = new JwtBearerEvents
+        {
+            OnAuthenticationFailed = RegularUserJwtAuthenticationBuilder.GetCustomOnAuthenticationFailedResult,
+            OnTokenValidated = context =>
+            {
+                if (context.Principal?.Identity is ClaimsIdentity identity
+                    && context.Principal.HasClaim(claim => claim.Type == ClaimTypes.Role && claim.Value == SecurityRoles.ExternalSystem)
+                    && !identity.HasClaim(claim => claim.Type == ExternalSystemClaims.AuthenticationType))
+                {
+                    identity.AddClaim(new Claim(ExternalSystemClaims.AuthenticationType, ExternalSystemAuthenticationType.Token.ToString()));
+                }
+                return Task.CompletedTask;
+            }
+        };
     }
 
     private static bool HasBearerToken(HttpContext context)

--- a/Cause.SecurityManagement/Cause.SecurityManagement.csproj
+++ b/Cause.SecurityManagement/Cause.SecurityManagement.csproj
@@ -17,7 +17,7 @@
 authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
 is unchanged. All published packages must be upgraded together.
     </PackageReleaseNotes>
-    <Version>10.5.0</Version>
+    <Version>10.5.0-beta1</Version>
     <AssemblyVersion>10.5.0</AssemblyVersion>
     <FileVersion>10.5.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Cause.SecurityManagement/Cause.SecurityManagement.csproj
+++ b/Cause.SecurityManagement/Cause.SecurityManagement.csproj
@@ -12,10 +12,14 @@
     <Description>ASP.NET Core HTTP integration (controllers, authentication, authorization) for Cause.SecurityManagement.Core.</Description>
     <Copyright>CAUCA 9-1-1 (c) 2025</Copyright>
     <PackageTags>Cause Security Management AspNetCore Http Controllers Cauca</PackageTags>
-    <PackageReleaseNotes>Add per-system ExternalSystem authentication method (Token/Certificate) with strict binding and a new AddDualExternalSystemAuthentication scheme that routes each request to certificate or JWT bearer. The authenticated principal is stamped with an externalSystemAuthenticationType claim (Certificate by the certificate handler; Token via OnTokenValidated, gated on the ExternalSystem role) so consumers can tell internal token callers from external certificate callers. Adds the split-out Cause.SecurityManagement.Wolverine.ExternalSystem endpoints package (logon/refresh/GetCurrentUser). NOTE: AuthenticationType defaults to Token; existing certificate-based external systems must be set to Certificate. The ExternalSystems table needs a non-nullable AuthenticationType column (default 0 = Token); this library ships no migrations.</PackageReleaseNotes>
-    <Version>10.4.0</Version>
-    <AssemblyVersion>10.4.0</AssemblyVersion>
-    <FileVersion>10.4.0</FileVersion>
+    <PackageReleaseNotes>
+10.5.0 — Adds AddExternalSystemTokenAuthentication for token-only external-system
+authentication (no client certificate). Backwards compatible: AddDualExternalSystemAuthentication
+is unchanged. All published packages must be upgraded together.
+    </PackageReleaseNotes>
+    <Version>10.5.0</Version>
+    <AssemblyVersion>10.5.0</AssemblyVersion>
+    <FileVersion>10.5.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

Adds a public **`AddExternalSystemTokenAuthentication`** for APIs that authenticate external systems by **bearer token only (no client certificate)**. The existing `AddDualExternalSystemAuthentication` (certificate + token) is the only public option today, and its token-only building blocks are `internal`; this fills that gap for consumers like the SurviRao-Transfer internal API.

Also fixes a pre-existing integration-test bug that made the whole integration suite unrunnable locally.

## Changes

- **`AddExternalSystemTokenAuthentication`** — registers a single JWT bearer scheme as the default (no certificate handler, no policy scheme) plus the shared `ExternalSystemSidClaimsTransformer`; null-guards the config.
- **DRY refactor** — the JWT bearer options are extracted into a private `ConfigureExternalSystemTokenBearer` helper reused by both the dual and the new token-only method. `AddDualExternalSystemAuthentication` behavior is **byte-for-byte unchanged**.
- **Test-infra fix** — `DatabaseFixture` (the `[SetUpFixture]` that starts the shared Postgres Testcontainer) lived in `...Integration.Tests.Infrastructure`, so NUnit only applied its `OneTimeSetUp` to that namespace and its descendants — never the sibling test namespaces (`.Authentication`, `.Management`, `.Registration`). Result: the container never started and all 64 integration tests threw `NullReferenceException` at setup. Moving the fixture to the root test namespace fixes it; all 64 now pass.
- **Coordinated version** → `10.5.0-beta1` across all four published packages (per `docs/RELEASING.md`).

## Tests
- `ExternalSystemAuthenticationExtensionsTests` 11/11 (7 existing + 4 new for the token-only method).
- Full library suite green: 39 + 208 + 64.
- A final whole-branch review returned **ready for final release**, no defects.

## Before the final release
This branch carries the **prerelease** `10.5.0-beta1` (already on CaucaNuget for the internal API to test against). To cut the final `10.5.0`: flip the four `<Version>` from `10.5.0-beta1` to `10.5.0` (AssemblyVersion/FileVersion and release notes already read final), then `release.ps1` and tag `v10.5.0` per `docs/RELEASING.md`.

## Notes
- Pre-existing, non-blocking: `Cause.SecurityManagement.Wolverine.ExternalSystem` has no packaged README (informational NuGet pack notice only).
- `docs/RELEASING.md` prose says "three published packages" while its table lists four — minor doc inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
